### PR TITLE
Add a few helper methods to ease usage a bit.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import { combineReducers } from 'redux';
 import { createAction } from 'redux-actions';
 import { snakeCase, camelCase, endsWith } from 'lodash';
 
@@ -84,5 +85,61 @@ export default class Model {
     this.dispatch = store.dispatch;
     this.api.getState = store.getState;
     this.api.getMyState = () => store.getState()[this.config.name];
+  }
+}
+
+/**
+ * Combine a set of Model reducers.
+ *
+ * @param {(array|object)} models - An array or object containing Model objects.
+ * @return {function} A combined redux reducer
+ */
+export function combineModelReducers(models) {
+  let reducers = {};
+
+  _iterateModels(models, (model) => {
+    reducers[model.name] = model.reducer;
+  });
+
+  return combineReducers(reducers);
+}
+
+/**
+ * Initialize a set of Models
+ *
+ * @param {(array|object)} models - An array or object containing Model objects.
+ * @param {object} store - A redux store.
+ */
+export function initModels(models, store) {
+  _iterateModels(models, (model) => {
+    model.init(store);
+  });
+}
+
+/**
+ * Iterate over an array or object containing Model objects. Non-Model objects
+ * are skipped silently.
+ *
+ * @param {(array|object)} models - An array or object containing Model objects.
+ * @param {function} cb - The function to invoke with each Model object.
+ */
+function _iterateModels(models, cb) {
+  if (models instanceof Array) {
+    models.forEach((model) => {
+      if (typeof model === 'object' && model.constructor.name === 'Model') {
+        cb(model);
+      }
+    });
+  } else if (typeof models === 'object') {
+    for (let key in models) {
+      if (models.hasOwnProperty(key)) {
+        let model = models[key];
+        if (typeof model === 'object' && model.constructor.name === 'Model') {
+          cb(model);
+        }
+      }
+    }
+  } else {
+    throw new TypeError("Parameter 'models' must be an array or object, not " + (typeof models));
   }
 }


### PR DESCRIPTION
In the real-world, you will likely have quite a few models, so reduce the boilerplate when setting up the store, I suggest 2 new helper functions:
- `combineModelReducers` - Combines a set of ReduxModel reducers.
- `initModels` - Initializes a set of ReduxModels.

So, a developer may create a `models/index.js` module which just exports all of the models:

``` javascript
import user from './user';
import entries from './entries';
import comments from './comments';

export {
  user,
  entries,
  comments,
};
```

Then in the `configureStore.js`, you can use the new functions like so:

``` javascript
import { createStore, applyMiddleware } from 'redux';
import createLogger from 'redux-logger';
import thunkMiddleware from 'redux-thunk';

// import the new helper functions
import { combineModelReducers, initModels } from 'redux-easy-models'

//models
import * as models from './models';

// combine all of the ReduxModel reducers
const reducers = combineModelReducers(models);

const logger = createLogger();
const store = createStore(
    reducers,
    applyMiddleware(...[thunkMiddleware, logger])
);

// init all the ReduxModels
initModels(models, store);
```
